### PR TITLE
Updated _node_comment partial (#5119)

### DIFF
--- a/app/views/dashboard/_node_comment.html.erb
+++ b/app/views/dashboard/_node_comment.html.erb
@@ -3,9 +3,9 @@
 
     <div class="header-icon">
      <% if node.aid == 0 %>
-      <a href="<% if node.parent.has_power_tag('question') %><%= node.parent.path(:question) %>#anwer-0-comment<% else %><%= node.parent.path %>#comments<% end %>"> <i class="fa fa-comment-o"> <%= node.parent.comments.count %> </i> </a>
+      <a href="<% if node.parent.has_power_tag('question') %><%= node.parent.path(:question) %>#answer-0-comment<% else %><%= node.parent.path %>#comments<% end %>"> <i class="fa fa-comment-o"> <%= node.parent.fetch_comments(current_user).count %></i> </a>
       <% else %>
-      <a href="<%= node.parent.path(:question) %>#answer-<%= node.answer.id %>-comment"> <i class="fa fa-comment-o"> 
+      <a href="<%= node.parent.path(:question) %>#answer-<%= node.answer.id %>-comment"> <i class="fa fa-comment-o"> </i>
       <% end %> 
       </a>
       <a href="/n/<%= node.parent.id %>"><i class="fa fa-link"></i></a>


### PR DESCRIPTION
#5111 
I made the required change in L6. Now it uses the function fetch_comments() to find the number of comments of the current user only instead of total number of comments. In L8, the tag is closed.

Fixes #0000 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
